### PR TITLE
Add `es_es` and `pt_br` translations

### DIFF
--- a/src/main/resources/assets/basalt-crusher/lang/es_es.json
+++ b/src/main/resources/assets/basalt-crusher/lang/es_es.json
@@ -1,0 +1,15 @@
+{
+  "block.basalt-crusher.basalt_crusher":      "Trituradora de basalto",
+  "block.basalt-crusher.gravel_mill":         "Molino de grava",
+  "block.basalt-crusher.grizzly":             "Canoso",
+
+  "item.basalt-crusher.basalt_crusher":       "Trituradora de basalto",
+  "item.basalt-crusher.gravel_mill":          "Molino de grava",
+  "item.basalt-crusher.grizzly":              "Canoso",
+
+  "item.basalt-crusher.iron_jaw_liner":       "Mandíbula de hierro",
+  "item.basalt-crusher.diamond_jaw_liner":    "Mandíbula de diamante",
+  "item.basalt-crusher.netherite_jaw_liner":  "Mandíbula de netherita",
+
+  "item.basalt-crusher.mill_rod_charge":      "Carga de molino de barras"
+}

--- a/src/main/resources/assets/basalt-crusher/lang/pt_br.json
+++ b/src/main/resources/assets/basalt-crusher/lang/pt_br.json
@@ -1,0 +1,15 @@
+{
+  "block.basalt-crusher.basalt_crusher":      "Triturador de basalto",
+  "block.basalt-crusher.gravel_mill":         "Moinho de cascalho",
+  "block.basalt-crusher.grizzly":             "Grisalho",
+
+  "item.basalt-crusher.basalt_crusher":       "Triturador de basalto",
+  "item.basalt-crusher.gravel_mill":          "Moinho de cascalho",
+  "item.basalt-crusher.grizzly":              "Grisalho",
+
+  "item.basalt-crusher.iron_jaw_liner":       "Mandíbula de ferro",
+  "item.basalt-crusher.diamond_jaw_liner":    "Mandíbula de diamante",
+  "item.basalt-crusher.netherite_jaw_liner":  "Mandíbula de netherita",
+
+  "item.basalt-crusher.mill_rod_charge":      "Carga de moinho de hastes"
+}


### PR DESCRIPTION
## Additions

- `es_es` (Castilian Spanish)
- `pt_br` (Brazilian Portuguese)

## Notes

- Title of the Basalt Crusher overlaps with some of the image when in the GUI with both translations.
- You might want to leave out the "GRIZ" text from the Grizzly machine, since it's different in other languages.